### PR TITLE
Updated mcp.json to provide secret more securely; disabled app insigh…

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,16 +1,29 @@
 {
+	"inputs": [
+		{
+		"type": "promptString",
+		"id": "functions-key",
+		"description": "Functions App Key",
+		"password": true
+		},
+		{
+		"type": "promptString",
+		"id": "functions-name",
+		"description": "Functions App Name",
+		"password": false
+		}
+	],
 	"servers": {
 		"local-mcp-server": {
-			"url": "http://0.0.0.0:7071/mcp",
+			"url": "http://0.0.0.0:8080/mcp",
 			"type": "http"
 		},
 		"remote-mcp-server": {
             "type": "http",
-            "url": "https://{functionapp-name}.azurewebsites.net/mcp",
+            "url": "https://${input:functions-name}.azurewebsites.net/mcp",
             "headers": {
-                "x-functions-key": "{access key}"
+                "x-functions-key": "${input:functions-key}"
             }
         }
-	},
-	"inputs": []
+	}
 }

--- a/local.settings.json
+++ b/local.settings.json
@@ -1,6 +1,7 @@
 {
     "IsEncrypted": false,
     "Values": {
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+        "AzureWebJobsFeatureFlags": "DisableDiagnosticEventLogging"
     }
 }


### PR DESCRIPTION
- Added `inputs` in mcp.json to have VSCode prompt for secret (safer, prevents accidental push of secrets)
- Disable the diagnostics logging feature for local development