### PR TITLE
fix deployment race condition

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to .NET Functions",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:azureFunctions.pickProcess}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "azureFunctions.deploySubpath": "bin/Release/net8.0/publish",
+    "azureFunctions.projectLanguage": "C#",
+    "azureFunctions.projectRuntime": "~4",
+    "debug.internalConsoleOptions": "neverOpen",
+    "azureFunctions.preDeployTask": "publish (functions)"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "clean (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "build (functions)",
+			"command": "dotnet",
+			"args": [
+				"build",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean (functions)",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "clean release (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "publish (functions)",
+			"command": "dotnet",
+			"args": [
+				"publish",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean release (functions)",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"type": "func",
+			"dependsOn": "build (functions)",
+			"options": {
+				"cwd": "${workspaceFolder}/bin/Debug/net8.0"
+			},
+			"command": "host start",
+			"isBackground": true,
+			"problemMatcher": "$func-dotnet-watch"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Ensure you have the following installed:
 1. Click on the Copilot icon at the top and change to _Agent_ mode in the question window. 
 1. Ask "What is the weather in NYC?" Copilot should call the weather tools to help answer this question. 
 
+> [!NOTE]
+> You may see logs saying `Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://127.0.0.1:63164/, Response status code: 404`. This is expected and does not affect the running server. 
+
 ### Deploy 
 
 In the root directory, and run `azd up`. This command will create and deploy the app, plus other required resources. 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -124,6 +124,7 @@ module mcpApiModule './app/apim-mcp/mcp-api.bicep' = {
   dependsOn: [
     appServicePlan
     api
+    storagePrivateEndpoint
   ]
 }
 


### PR DESCRIPTION
When running azd up, there was an intermittent issue caused by race conditions: 

```
ERROR: error executing step command 'provision': deployment failed: error deploying infrastructure: deploying to subscription:
 
Deployment Error Details:
BadRequest: Encountered an error (InternalServerError) from host runtime.
- Encountered an error (InternalServerError) from host runtime.
```

We believe this happens because `mcpApiModule` needs a function key from the function's host. But the private endpoint might be in the middle of setting up, so the host can't get the key from the storage account. Thus, we added `storagePrivateEndpoint` as a dependsOn component in the `mcpApiModule`.

Also -
- Added some files in the `.vscode` folder to help users set up the project environment for VSCode
- Added a note about benign log